### PR TITLE
Pin a version for pycryptodome to 3.22.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 dependencies = [
     "dissect.cstruct>=4,<5",
     "dissect.util>=3,<4",
-    "pycryptodome",
+    "pycryptodome==3.22.0",
     "argon2-cffi",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
Version 3.23.0 of pycryptodome doesn't allow adding ciphers in the way
we do it now. Therefore it is best to pin it to 3.22.0 for now
