### PR TITLE
Add stricter Ruff linting

### DIFF
--- a/dissect/fve/__init__.py
+++ b/dissect/fve/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dissect.fve.exception import Error
 
 __all__ = [

--- a/dissect/fve/bde/__init__.py
+++ b/dissect/fve/bde/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dissect.fve.bde.bde import BDE, is_bde_volume
 
 __all__ = [

--- a/dissect/fve/bde/bde.py
+++ b/dissect/fve/bde/bde.py
@@ -30,7 +30,7 @@ from dissect.fve.bde.c_bde import (
     c_bde,
 )
 from dissect.fve.bde.eow import EowInformation
-from dissect.fve.bde.information import Dataset, Information, KeyDatum, VmkInfoDatum
+from dissect.fve.bde.information import Dataset, Information, KeyDatum
 from dissect.fve.bde.key import derive_recovery_key, derive_user_key, stretch
 from dissect.fve.crypto import create_cipher
 from dissect.fve.exception import InvalidHeaderError
@@ -38,6 +38,8 @@ from dissect.fve.exception import InvalidHeaderError
 if TYPE_CHECKING:
     from collections.abc import Iterator
     from uuid import UUID
+
+    from dissect.fve.bde.information import VmkInfoDatum
 
 Run = tuple[int, int, int]
 

--- a/dissect/fve/bde/c_bde.py
+++ b/dissect/fve/bde/c_bde.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from uuid import UUID
 
 from dissect.cstruct import cstruct

--- a/dissect/fve/crypto/__init__.py
+++ b/dissect/fve/crypto/__init__.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 # Only pycryptodome is supported right now
 from dissect.fve.crypto import _pycryptodome
-from dissect.fve.crypto.base import Cipher, Plain, Plain64, Plain64BE
+from dissect.fve.crypto.base import Plain, Plain64, Plain64BE
+
+if TYPE_CHECKING:
+    from dissect.fve.crypto.base import Cipher
 
 IV_MODE_MAP = {
     "plain": Plain,

--- a/dissect/fve/crypto/argon2.py
+++ b/dissect/fve/crypto/argon2.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 try:
     from dissect.fve import _native
 

--- a/dissect/fve/exception.py
+++ b/dissect/fve/exception.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 class Error(Exception):
     pass
 

--- a/dissect/fve/luks/__init__.py
+++ b/dissect/fve/luks/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dissect.fve.luks.luks import LUKS, is_luks_volume
 
 __all__ = [

--- a/dissect/fve/luks/luks.py
+++ b/dissect/fve/luks/luks.py
@@ -13,10 +13,12 @@ from dissect.fve.luks.c_luks import (
     SECONDARY_HEADER_OFFSETS,
     c_luks,
 )
-from dissect.fve.luks.metadata import Digest, Keyslot, Metadata, Segment
+from dissect.fve.luks.metadata import Metadata
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+    from dissect.fve.luks.metadata import Digest, Keyslot, Segment
 
 
 class LUKS:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,8 +111,25 @@ select = [
   "PERF",
   "FURB",
   "RUF",
+  "D"
 ]
-ignore = ["E203", "B904", "UP024", "ANN002", "ANN003", "ANN204", "ANN401", "SIM105", "TRY003"]
+ignore = [
+    "E203", "B904", "UP024", "ANN002", "ANN003", "ANN204", "ANN401", "SIM105", "TRY003", "PLC0415",
+    # Ignore some pydocstyle rules for now as they require a larger cleanup
+    "D1",
+    "D205",
+    "D301",
+    "D417",
+    # Seems bugged: https://github.com/astral-sh/ruff/issues/16824
+    "D402",
+]
+future-annotations = true
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"
+
+[tool.ruff.lint.flake8-type-checking]
+strict = true
 
 [tool.ruff.lint.per-file-ignores]
 "tests/_docs/**" = ["INP001"]
@@ -120,6 +137,7 @@ ignore = ["E203", "B904", "UP024", "ANN002", "ANN003", "ANN204", "ANN401", "SIM1
 [tool.ruff.lint.isort]
 known-first-party = ["dissect.fve"]
 known-third-party = ["dissect"]
+required-imports = ["from __future__ import annotations"]
 
 [tool.setuptools.packages.find]
 include = ["dissect.*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,7 +103,7 @@ select = [
   "SLOT",
   "SIM",
   "TID",
-  "TCH",
+  "TC",
   "PTH",
   "PLC",
   "TRY",

--- a/tests/_docs/conf.py
+++ b/tests/_docs/conf.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 extensions = [
     "autoapi.extension",
     "sphinx.ext.autodoc",


### PR DESCRIPTION
Add stricter rules (doctstyle) + Add annotations import to ruff isort required imports.

Code change are only related to addition of from __future__ import annotations
Regarding few change, I suggest to not add this commit to git blame ignore file.

* fixes #25 